### PR TITLE
docs: fix typo in reconnection instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use the awesome: https://github.com/alexellis/k3sup
 
 ## Reconnecting into an existing K3s/k3sup setup if the workstation is delte
 * Get the k3s.yaml file from the master node. This would be in the /etc/rancher/k3s folder
-* copyt this file as "config" into $HOME/.kube folder
+* copy this file as "config" into $HOME/.kube folder
 * Update config file to point to correct master node ip address or hostname
 * confirm with kubectl on workstation
 


### PR DESCRIPTION
## Summary
- fix typo in reconnecting into existing K3s/k3sup setup instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689546b699bc832b93af972a338d1e5d