### PR TITLE
Fix VLC playback loop

### DIFF
--- a/adhanPlayer.py
+++ b/adhanPlayer.py
@@ -150,8 +150,8 @@ if __name__ == '__main__':
                                             playerLogger.info("main:Playing adhan file {} for prayer {}".format(fileName, prayer))
                                             vlcplayer = vlc.MediaPlayer(fileName)
                                             vlcplayer.play()
-                                            while vlcplayer.is_playing == True:
-                                                continue
+                                            while vlcplayer.is_playing():
+                                                time.sleep(0.1)
                                             pass
                                     except Exception as err:
                                         playerLogger.error("main: error in playing file {}".format(err))


### PR DESCRIPTION
## Summary
- replace direct `is_playing` flag check with `vlcplayer.is_playing()` in adhan playback loop
- add brief sleep to prevent busy waiting while VLC plays

## Testing
- `python -m unittest test.AdhanPlayerTest`


------
https://chatgpt.com/codex/tasks/task_e_689546bb9e1c832b8420b812ec52e2c0