### PR TITLE
Fix prayer time calculation bug and add test

### DIFF
--- a/adhanPlayer.py
+++ b/adhanPlayer.py
@@ -101,21 +101,33 @@ def setPrometheusTimeToPrayerGuages(prayer,thisPrayerTime):
     if (prayer.lower() == "isha"):
         isha_prayer_guage.set(thisPrayerTime.timestamp())
 
-def calculateTimeToPrayer(pryayerTimes):
+def calculateTimeToPrayer(prayerTimes):
+    """Update Prometheus gauges with the provided prayer times.
+
+    Args:
+        prayerTimes (dict): Mapping of prayer names to time strings in
+            HH:MM format.
+    """
 
     playerLogger.info("calculateTimeToPrayer: Starting")
     currentTime = datetime.datetime.now()
-    
+
     for prayer in prayerTimes:
-        prayerHour = (int)(prayerTimes[prayer].split(':')[0])
-        prayerMinute = (int)(prayerTimes[prayer].split(':')[1])
-        thisPrayerTime = datetime.datetime.combine(datetime.date.today(), datetime.time(prayerHour,prayerMinute))
-        setPrometheusTimeToPrayerGuages(prayer,thisPrayerTime)
-        playerLogger.debug("calculateTimeToPrayer: " +  str(prayer) + " is at " + str(thisPrayerTime) )
+        prayerHour = int(prayerTimes[prayer].split(':')[0])
+        prayerMinute = int(prayerTimes[prayer].split(':')[1])
+        thisPrayerTime = datetime.datetime.combine(
+            datetime.date.today(), datetime.time(prayerHour, prayerMinute)
+        )
+        setPrometheusTimeToPrayerGuages(prayer, thisPrayerTime)
+        playerLogger.debug(
+            "calculateTimeToPrayer: " + str(prayer) + " is at " + str(thisPrayerTime)
+        )
     return None
+
+
 ####
 timestamp = None
-pryayerTimes = None
+prayerTimes = None
 adhanPlayed = {}
 
 

--- a/test/AdhanPlayerTest.py
+++ b/test/AdhanPlayerTest.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import sys
+import datetime
 import adhanPlayer
 class TestAdhanPlayerMethods(unittest.TestCase):
     
@@ -14,12 +15,27 @@ class TestAdhanPlayerMethods(unittest.TestCase):
 
     def test_StripUnwantedFilesFromArray_In_MediaFolder(self):
         
-        for root, dirs, files in os.walk('media',topdown=True):
-                  #print files
-                  #print "files after strip :", adhanPlayer.StripUnwantedFilesFromArray(files)
-                  fArray = adhanPlayer.StripUnwantedFilesFromArray(files)
-                  for f in fArray:
-                      self.assertNotEqual(f[0],'.')
+        for root, dirs, files in os.walk('media', topdown=True):
+            #print files
+            #print "files after strip :", adhanPlayer.StripUnwantedFilesFromArray(files)
+            fArray = adhanPlayer.StripUnwantedFilesFromArray(files)
+            for f in fArray:
+                self.assertNotEqual(f[0], '.')
+
+    def test_calculateTimeToPrayer_uses_passed_prayer_times(self):
+        """calculateTimeToPrayer should rely on its argument, not global state."""
+
+        # Global prayerTimes intentionally set to an incorrect value
+        adhanPlayer.prayerTimes = {'Fajr': '00:00'}
+
+        # Provide correct times through the function argument
+        test_times = {'Fajr': '05:00'}
+        adhanPlayer.calculateTimeToPrayer(test_times)
+
+        expected = datetime.datetime.combine(
+            datetime.date.today(), datetime.time(5, 0)
+        ).timestamp()
+        self.assertEqual(adhanPlayer.fajr_prayer_guage._value.get(), expected)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fix `calculateTimeToPrayer` to use passed prayer times and document function
- clean up global variable name
- add regression test for `calculateTimeToPrayer`

## Testing
- `pytest test/AdhanPlayerTest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895454d24f0832bae93d5a182510ce3