### PR TITLE
Add checks for adhan file existence and type

### DIFF
--- a/test/AdhanPlayerTest.py
+++ b/test/AdhanPlayerTest.py
@@ -3,23 +3,24 @@ import os
 import sys
 import adhanPlayer
 class TestAdhanPlayerMethods(unittest.TestCase):
-    
+
     def test_GetAdhanFile(self):
-       fajr =  adhanPlayer.GetAdhanFile("Fajr")
-       #print fajr
-       self.assertIsNotNone(fajr)
-       asr =  adhanPlayer.GetAdhanFile("Asr")
-       #print asr
-       self.assertIsNotNone(asr)
+        fajr = adhanPlayer.GetAdhanFile("Fajr")
+        self.assertIsNotNone(fajr)
+        self.assertTrue(os.path.exists(fajr))
+        self.assertTrue(fajr.endswith(".mp3"))
+
+        asr = adhanPlayer.GetAdhanFile("Asr")
+        self.assertIsNotNone(asr)
+        self.assertTrue(os.path.exists(asr))
+        self.assertTrue(asr.endswith(".mp3"))
 
     def test_StripUnwantedFilesFromArray_In_MediaFolder(self):
-        
-        for root, dirs, files in os.walk('media',topdown=True):
-                  #print files
-                  #print "files after strip :", adhanPlayer.StripUnwantedFilesFromArray(files)
-                  fArray = adhanPlayer.StripUnwantedFilesFromArray(files)
-                  for f in fArray:
-                      self.assertNotEqual(f[0],'.')
+        for root, dirs, files in os.walk('media', topdown=True):
+            fArray = adhanPlayer.StripUnwantedFilesFromArray(files)
+            for f in fArray:
+                self.assertNotEqual(f[0], '.')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- enhance GetAdhanFile test to assert returned paths exist and point to mp3 files

## Testing
- `pytest test/AdhanPlayerTest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689547c02798832bbe7cd3e13b454ad4